### PR TITLE
Increased MAX_MAPS to a larger size

### DIFF
--- a/global.h
+++ b/global.h
@@ -38,7 +38,7 @@ typedef struct AsyncFile {
     int completed;         // 0 = pending, 1 = done
     int success;           // 0 = failed, 1 = succeeded
     CURL *easy_handle;     // handle for non-blocking
-	FILE *fp			   // store opened tmp file
+	FILE *fp;			   // store opened tmp file
 } AsyncFile;
 
 typedef struct AsyncStage {

--- a/jumpmod.c
+++ b/jumpmod.c
@@ -7667,6 +7667,7 @@ void shiftent (edict_t *ent)
 	}
 }
 
+maplist_uid_file maplistinuid[MAX_MAPS];
 void removemapfrom_uid_file(int uid){
 
 	FILE	*f;
@@ -7675,7 +7676,6 @@ void removemapfrom_uid_file(int uid){
 	cvar_t	*port;
 	cvar_t	*tgame;
 	char	name[256];
-    maplist_uid_file maplistinuid[MAX_MAPS];
 	char	mapname[256];
 
 	tgame = gi.cvar("game", "", 0);

--- a/jumpmod.c
+++ b/jumpmod.c
@@ -7677,6 +7677,8 @@ void removemapfrom_uid_file(int uid){
 	char	name[256];
     static maplist_uid_file maplistinuid[MAX_MAPS]; // too large to alloc on the stack
 	char	mapname[256];
+    
+    memset(maplistinuid, 0, sizeof(maplistinuid));
 
 	tgame = gi.cvar("game", "", 0);
 	port = gi.cvar("port", "", 0);

--- a/jumpmod.c
+++ b/jumpmod.c
@@ -7667,7 +7667,6 @@ void shiftent (edict_t *ent)
 	}
 }
 
-maplist_uid_file maplistinuid[MAX_MAPS];
 void removemapfrom_uid_file(int uid){
 
 	FILE	*f;
@@ -7676,6 +7675,7 @@ void removemapfrom_uid_file(int uid){
 	cvar_t	*port;
 	cvar_t	*tgame;
 	char	name[256];
+    static maplist_uid_file maplistinuid[MAX_MAPS]; // too large to alloc on the stack
 	char	mapname[256];
 
 	tgame = gi.cvar("game", "", 0);

--- a/jumpmod.h
+++ b/jumpmod.h
@@ -7,7 +7,7 @@
 #define		HOOK_READY	0
 #define		HOOK_OUT	1
 #define		HOOK_ON		2
-#define MAX_MAPS           3584    // 1.35global
+#define MAX_MAPS           8192
 #define MAX_MAPNAME_LEN    32 
 #define MAX_MANUAL           32 
 #define MAX_MANUAL_LEN    128 


### PR DESCRIPTION
Fixes an issue where increasing MAX_MAPS can cause too much memory to be allocated on the stack in Linux environments.